### PR TITLE
using docker exec rather than run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,8 +118,8 @@ services:
     image: arches/arches_webpack
     build: ./webpack
     environment:
-      - COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}"
-      - DJANGO_DEBUG="${DJANGO_DEBUG}"
+      COMPOSE_PROJECT_NAME: "${COMPOSE_PROJECT_NAME}"
+      DJANGO_DEBUG: "${DJANGO_DEBUG}"
     deploy:
       restart_policy:
         condition: on-failure

--- a/webpack/webpack_entrypoint.sh
+++ b/webpack/webpack_entrypoint.sh
@@ -7,4 +7,4 @@ until nc -z arches 8000; do
 	echo "Waiting for the arches server application to start..."
   	sleep 5s & wait ${!}
 done
-exec docker compose run arches run_setup_webpack
+exec docker compose exec --no-TTY arches ./entrypoint.sh run_setup_webpack


### PR DESCRIPTION
Hello,

`docker compose run arches run_setup_webpack` was restarting a new container each time, leaving lots of them behind.

My first idea was to remove them automatically with:
`docker compose run --rm arches run_setup_webpack`

but then `exec` seems a lighter.

It required a change in the way the `environment` vars are declared. 