### PR TITLE
Add a ontologies file path

### DIFF
--- a/arches/Dockerfile
+++ b/arches/Dockerfile
@@ -78,7 +78,7 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE 1
 
 # Setup needed directories
-RUN mkdir ${ARCHES_ROOT} && mkdir /var/log/supervisor && mkdir /var/log/celery
+RUN mkdir ${ARCHES_ROOT} && mkdir /var/log/supervisor && mkdir /var/log/celery && mkdir -p ${ARCHES_ROOT}/arches_data/ontologies
 
 # Get ready to do some code installation
 RUN apt-get update && apt-get install -y make software-properties-common


### PR DESCRIPTION
I have added a section to the Setup needed directories command in the Docker file that creates the file path needed for uploading ontologies to Arches. Since this is a fix path structure which all ontologies should follow it makes it easier for users to upload ontologies as it removes the required step to do this manually. User can then simply upload the required ontologies to this path and run the  load ontologies command. It was tested using the ontology downloaded from this repo: 'https://github.com/archesproject/cidoc-crm-ontology/archive/master.zip'